### PR TITLE
fix default config for debian 10

### DIFF
--- a/logrotate/files/logrotate.conf
+++ b/logrotate/files/logrotate.conf
@@ -3,7 +3,7 @@
 # rotate log files weekly
 {{ server.global_conf.rotate }}
 
-{%- if grains['os_family'] == "Debian" %}
+{%- if grains['os'] == "Ubuntu" %}
 
 # use the syslog group by default, since this is the owning group
 # of /var/log/syslog.
@@ -32,6 +32,7 @@ compress
 # packages drop log rotation information into this directory
 include /etc/logrotate.d
 
+{%- if grains['os'] != 'Debian' or grains['osmajorrelease'] < 10 %}
 # no packages own wtmp, or btmp -- we'll rotate them here
 /var/log/wtmp {
     missingok
@@ -47,6 +48,7 @@ include /etc/logrotate.d
     rotate 1
 }
 
+{%- endif %}
 # system-specific logs may be configured here
 {#-
 vim: syntax=jinja


### PR DESCRIPTION
Don't add values not used by debian, or debian buster.

I haven't seen "su root syslog" in logrotate.conf in debian, checked in debian 7, 9 and 10.
And debian 10 doesn't have /var/log/wtmp or /var/log/btmp in logrotate.conf