### PR TITLE
fix if pillar logrotate is not defined

### DIFF
--- a/logrotate/init.sls
+++ b/logrotate/init.sls
@@ -1,4 +1,4 @@
+{%- if salt['pillar.get']('logrotate:server') %}
 include:
-{%- if pillar.logrotate.server is defined %}
 - logrotate.server
 {%- endif %}


### PR DESCRIPTION
I add logrotate in salt/top to every server, but it failed for some of them because I didn't define anything in pillar, so pillar.logrotate doesn't exist. I like to do in that way, so I don't need to add a line to salt/top if I define values in pillar. Other formulas do in this way too.